### PR TITLE
Add empty body to authorization request in captureOrder method

### DIFF
--- a/src/lib/payment/paypal-client.js
+++ b/src/lib/payment/paypal-client.js
@@ -231,7 +231,8 @@ class PayPalClientFixed {
       headers: {
         'Authorization': `Bearer ${token}`,
         'Content-Type': 'application/json'
-      }
+      },
+      body: JSON.stringify({})
     });
 
     if (!response.ok) {


### PR DESCRIPTION
Add empty body to authorization request in captureOrder method (PayPalClientFixed.captureOrder)